### PR TITLE
bosh bootloader to 4.0.0

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -18,7 +18,7 @@
     bosh_cli_sha1_checksum: "7b7629fcdf8839cf29bf25d97e8ea6beb3b9a7b2"
     yaml_linux_version: "1.11"
     terraform_version: "0.9.11"
-    bosh_bootloader_version: "3.2.6"
+    bosh_bootloader_version: "4.0.0"
     postman_version: "5.1.2"
     postman_sha1_checksum: "59F1E93055159823146EBF1F50F8FAD384FCE5FE"
   gather_facts: yes


### PR DESCRIPTION
New major release, might not be backward compatible. See release notes:

https://github.com/cloudfoundry/bosh-bootloader/releases