### PR TITLE
terraform to 0.10.2

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -15,7 +15,7 @@
     bosh_cli_version: "2.0.28"
     bosh_cli_sha1_checksum: "7b7629fcdf8839cf29bf25d97e8ea6beb3b9a7b2"
     yaml_linux_version: "1.11"
-    terraform_version: "0.10.1"
+    terraform_version: "0.10.2"
     bosh_bootloader_version: "4.0.0"
     postman_version: "5.1.3"
     postman_sha1_checksum: "7010D79F3D088FB1F5157ED639515C273BA78BDC"


### PR DESCRIPTION
BUG FIXES:

* tools/terraform-bundle: Add missing Ui to ProviderInstaller (fix crash) (#15826)
* go-plugin: crash when server emits non-key-value JSON (go-plugin#43)