### PR TITLE
Revert "compliance masonry to 1.1.3"

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -11,7 +11,7 @@
     atom_version: "1.19.0"
     gradle_version: "4.0.2"
     go_version: "1.8.3"
-    compliance_masonry_version: "1.1.3"
+    compliance_masonry_version: "1.1.2"
     bosh_cli_version: "2.0.28"
     bosh_cli_sha1_checksum: "7b7629fcdf8839cf29bf25d97e8ea6beb3b9a7b2"
     yaml_linux_version: "1.11"


### PR DESCRIPTION
This reverts commit 6ead9705e6395a252aa4b65b614cc14b400797a0.

Looks like 1.1.3 was removed.