### PR TITLE
Install Java source code

### DIFF
--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -23,6 +23,7 @@
       - groovy
       - ldap-utils
       - openjdk-8-jdk
+      - openjdk-8-source
       - ant
       - gnome-terminal
       - ngrep


### PR DESCRIPTION
IntelliJ can detect when the sources are present and it makes
navigating the code much nicer